### PR TITLE
Install `wxmac@3.1.5` to support Erlang OTP24 observer

### DIFF
--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -5,6 +5,12 @@ tap 'homebrew/cask-fonts'
 tap 'homebrew/services'
 tap 'pmeinhardt/tools'
 
+# Required to install `wxmac@3.1.5`. Remove these extra
+# formulae as soon `wxmac@3.2` is released.
+# http://www.wxwidgets.org/
+# https://github.com/Homebrew/homebrew-core/blob/master/Formula/wxmac.rb
+tap 'dominicletz/homebrew-extra'
+
 # code apps
 cask 'firefox'
 cask 'iterm2'
@@ -42,7 +48,7 @@ brew 'rsync'
 brew 'tree'
 brew 'watch'               # execute command periodically
 brew 'wget'
-brew 'wxmac'               # for starting erlang observer / debugger
+brew 'wxmac@3.1.5'         # for starting erlang observer / debugger (OTP 24)
 
 # dev packages
 brew 'ansible'

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -8,6 +8,7 @@ export LSCOLORS="Gxfxcxdxbxegedabagacad"                # define colors for list
 export CLICOLOR=1                                       # enable colors for list command
 export ERL_AFLAGS="-kernel shell_history enabled"       # shell history for Erlang / Elixir
 export ERL_EPMD_ADDRESS=127.0.0.1                       # prevent epmd from exposing a port
+export KERL_BUILD_DOCS=yes                              # enable docs consultation for Erlang
 export HOMEBREW_BUNDLE_NO_LOCK=1                        # disable lockfile for brew bundle
 
 # PATH


### PR DESCRIPTION
Erlang OTP 24 requires `wxmac` version 3.1.x to start the `observer`, which is considered the development version (http://www.wxwidgets.org/news/2021/04/wxwidgets-3.1.5-released/).

Homebrew comes with the latest stable version for `wxmac` (v3.0.5)  and won't update the formula until the next stable version will be released (3.2).

btw, the observer now supports the Dark mode, yay 💪 

![image](https://user-images.githubusercontent.com/3228071/119233389-1e386e00-bb29-11eb-8491-b87e9d707109.png)
