### PR TITLE
Update `/etc/hosts` when a custom hostname is used

### DIFF
--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -19,6 +19,7 @@ cask 'rectangle'          # window management
 # dev apps
 cask 'chromedriver'
 cask 'docker'
+cask 'google-cloud-sdk'
 # cask 'google-chrome'
 cask 'insomnia'           # postman alternative
 cask 'visual-studio-code'
@@ -59,6 +60,7 @@ brew 'git-quick-stats'            # git repo stats
 brew 'hadolint'                   # lint dockerfiles
 brew 'highlight'                  # utility for converting code to rtf
 brew 'jq'                         # format JSON
+brew 'k9s'                        # Kubernetes CLI tool
 brew 'overmind'                   # Process manager (Procfile based)
 brew 'ripgrep'                    # search tool
 brew 'shellcheck'                 # Linter for shell scripts

--- a/mac/install.sh
+++ b/mac/install.sh
@@ -9,6 +9,10 @@ set -o pipefail
 
 source "../script/lib/utils.sh"
 
+# You can find more macOS defaults here:
+# - https://macos-defaults.com/
+# - https://github.com/mathiasbynens/dotfiles
+
 info "SET MACOS DEFAULTS…"
 
 # General

--- a/script/setup
+++ b/script/setup
@@ -20,4 +20,17 @@ info "SET COMPUTER NAME to '$name'…"
 sudo scutil --set ComputerName "$name"
 sudo scutil --set LocalHostName "$name"
 
+# Maybe update `/etc/hosts`
+LINE="127.0.0.1 $name"
+FILE='/etc/hosts'
+grep -xqF -- "$LINE" "$FILE" || {
+  echo "# --> Addeded by Dotfiles"
+  echo "# LocalHostName has changed from the default one."
+  echo '# The entry below fixes the Erlang distribution when'
+  echo '# starting the distribuited node with the `--sname` flag.'
+  echo "# See https://github.com/livebook-dev/livebook/issues/275#issuecomment-845850328"
+  echo "$LINE"
+  echo "# <--"
+} | sudo tee -a "$FILE"
+
 "$SCRIPT_DIR/install"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -164,3 +164,8 @@ autoload bashcompinit && bashcompinit                   # load bash completion
 
 # plugins
 source $ZSH_DIR/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+
+# Google Cloud SDK
+# (run `brew info google-cloud-sdk` to get the paths)
+source "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.zsh.inc"
+source "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.zsh.inc"


### PR DESCRIPTION
The Dotfiles setup script asks how the computer should be called.
This changes the `ComputerName` and the `LocalHostName`.
When setting a custom hostname the Erlang distribution cannot resolve anymore the node address started with the [`sname`](http://erlang.org/pipermail/erlang-questions/2006-December/024274.html) flag.

How to prove:

- Get the local hostname

```bash
> scutil --get LocalHostName
```

In a elixir interactive session:

```elixir
$ iex --sname foo
```

In another iex:

$ iex --sname bar
iex(1)> Node.connect(:"foo@LOCAL-HOST-NAME") # replace it with the result of the scutil command
```

The last command should return `true` if a connection is established, otherwise `false` when the connection attempt fails.

In my case, adding `127.0.0.1 LOCAL-HOST-NAME` fixed it.

Based on this issue https://github.com/livebook-dev/livebook/issues/275#issuecomment-845842873
