### PR TITLE
Update `/etc/hosts` when a custom hostname is used

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -20,4 +20,17 @@ info "SET COMPUTER NAME to '$name'…"
 sudo scutil --set ComputerName "$name"
 sudo scutil --set LocalHostName "$name"
 
+# Maybe update `/etc/hosts`
+LINE="127.0.0.1 $name"
+FILE='/etc/hosts'
+grep -xqF -- "$LINE" "$FILE" || {
+  echo "# --> Addeded by Dotfiles"
+  echo "# LocalHostName has changed from the default one."
+  echo '# The entry below fixes the Erlang distribution when'
+  echo '# starting the distribuited node with the `--sname` flag.'
+  echo "# See https://github.com/livebook-dev/livebook/issues/275#issuecomment-845850328"
+  echo "$LINE"
+  echo "# <--"
+} | sudo tee -a "$FILE"
+
 "$SCRIPT_DIR/install"


### PR DESCRIPTION
The Dotfiles setup script asks how the computer should be called.
This changes the `ComputerName` and the `LocalHostName`.
When setting a custom hostname the Erlang distribution cannot resolve anymore the node address started with the [`sname`](http://erlang.org/pipermail/erlang-questions/2006-December/024274.html) flag.

How to prove:

- Get the local hostname

```bash
> scutil --get LocalHostName
```

In a elixir interactive session:

```elixir
$ iex --sname foo
```

In another iex:

```elixir
$ iex --sname bar
iex(1)> Node.connect(:"foo@LOCAL-HOST-NAME") # replace it with the result of the scutil command
```

The last command should return `true` if a connection is established, otherwise `false` when the connection attempt fails.

In my case, adding `127.0.0.1 LOCAL-HOST-NAME` fixed it.

Related to this issue https://github.com/livebook-dev/livebook/issues/275#issuecomment-845842873
